### PR TITLE
Gather results from worker threads

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -4,10 +4,10 @@ use std::{thread, time};
 use boss::Boss;
 use std::io;
 
-fn process_data(msg: i32) {
+fn process_data(msg: i32) -> Result<i32, ()> {
     let one_second = time::Duration::from_millis(1000);
     thread::sleep(one_second);
-    println!("{}", msg);
+    Ok(msg)
 }
 
 fn main() -> io::Result<()> {
@@ -16,6 +16,11 @@ fn main() -> io::Result<()> {
         boss.send_data(i);
         println!("sent {}", i);
     }
-    boss.finish();
+    let res = boss.finish();
+    for r in res {
+        if let Ok(r) = r {
+            println!("{}", r);
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
Modify the worker threads to keep an array of the function results.
The caller can evaluate the results at the very end upon finish.

Signed-off-by: Jordi Carrillo <jordilin@gmail.com>